### PR TITLE
chunkserver basic implementation

### DIFF
--- a/chunkserver/pom.xml
+++ b/chunkserver/pom.xml
@@ -16,6 +16,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/chunkserver/src/main/java/com/example/chunkserver/ChunkServerController.java
+++ b/chunkserver/src/main/java/com/example/chunkserver/ChunkServerController.java
@@ -24,7 +24,10 @@ public class ChunkServerController {
         chunks.add(chunk);
         chunkStorage.put(filename, chunks);
         System.out.println("Stored ChunkID: " + chunk.getId() + ", for File: " + filename);
-
+        System.out.println("Current Chunks stored for file: "+filename);
+        for (Chunk c : chunks){
+            System.out.println(c.getId());
+        }
         return ResponseEntity.ok("Stored ChunkID: " + chunk.getId() + ", for File: " + filename);
     }
 

--- a/chunkserver/src/main/java/com/example/chunkserver/ChunkServerService.java
+++ b/chunkserver/src/main/java/com/example/chunkserver/ChunkServerService.java
@@ -1,0 +1,67 @@
+package com.example.chunkserver;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.*;
+
+import com.example.chunkserver.entity.Chunk;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChunkServerService {
+    public void storeChunk(String filename, Chunk chunk) throws RuntimeException {
+        String basePath = System.getProperty("user.dir") + File.separator + "files";
+        File directory = new File(basePath, filename);
+
+        if (!directory.exists()) {
+            boolean dirCreated = directory.mkdirs();
+            if (!dirCreated) {
+                System.err.println("Failed to create directory: " + directory.getAbsolutePath());
+                return;
+            }
+        }
+
+        File chunkFile = new File(directory, chunk.getId() + ".txt");
+        try (FileWriter writer = new FileWriter(chunkFile)) {
+            writer.write(chunk.getContent());
+            System.out.println("Chunk stored successfully: " + chunkFile.getAbsolutePath());
+        } catch (IOException e) {
+            System.err.println("Error writing chunk to file: " + chunkFile.getAbsolutePath());
+            e.printStackTrace();
+        }
+    }
+
+    public Map<String, List<Chunk>> retrieveChunks() {
+        Map<String, List<Chunk>> storage = new HashMap<>();
+        File baseDirectory = new File(System.getProperty("user.dir")+ File.separator + "files");
+
+        if (!baseDirectory.exists()){
+            if (baseDirectory.mkdirs()) {
+                System.out.println("Directory created: " + baseDirectory.getAbsolutePath());
+            } else {
+                System.err.println("Failed to create directory: " + baseDirectory.getAbsolutePath());
+            }
+        }
+
+        for (File dir : Objects.requireNonNull(baseDirectory.listFiles(File::isDirectory))) {
+            List<Chunk> chunks = new ArrayList<>();
+
+            for (File file : Objects.requireNonNull(dir.listFiles((d, name) -> name.endsWith(".txt")))) {
+                try {
+                    String content = Files.readString(file.toPath());
+                    String chunkId = file.getName().replace(".txt", "");
+                    chunks.add(new Chunk(chunkId, content));
+                } catch (IOException e) {
+                    System.err.println("Error reading file: " + file.getAbsolutePath());
+                    e.printStackTrace();
+                }
+            }
+
+            storage.put(dir.getName(), chunks);
+        }
+        return storage;
+    }
+
+}

--- a/chunkserver/src/main/java/com/example/chunkserver/ChunkServerStartupService.java
+++ b/chunkserver/src/main/java/com/example/chunkserver/ChunkServerStartupService.java
@@ -1,0 +1,35 @@
+package com.example.chunkserver;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class ChunkServerStartupService {
+
+    @Value("${chunkmaster.url}")
+    private String chunkMasterUrl;
+
+    @Value("${server.port}")
+    private int serverPort;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        String chunkServerIp = "127.0.0.1"; // Replace with actual IP if needed
+        String chunkServerUrl = "http://" + chunkServerIp + ":" + serverPort;
+
+        RestTemplate restTemplate = new RestTemplate();
+        String requestUrl = chunkMasterUrl + "/addChunkServer?chunkServerUrl=" + chunkServerUrl;
+        System.out.println(requestUrl);
+        ResponseEntity<String> response = restTemplate.postForEntity(requestUrl, null, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            System.out.println("Successfully registered with Chunk Master");
+        } else {
+            throw new RuntimeException("Failed to register with Chunk Master");
+        }
+    }
+}

--- a/chunkserver/src/main/java/com/example/chunkserver/entity/Chunk.java
+++ b/chunkserver/src/main/java/com/example/chunkserver/entity/Chunk.java
@@ -1,0 +1,8 @@
+package com.example.chunkserver.entity;
+import lombok.Getter;
+
+@Getter
+public class Chunk {
+    String id;
+    String content;
+}

--- a/chunkserver/src/main/java/com/example/chunkserver/entity/Chunk.java
+++ b/chunkserver/src/main/java/com/example/chunkserver/entity/Chunk.java
@@ -1,7 +1,9 @@
 package com.example.chunkserver.entity;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class Chunk {
     String id;
     String content;

--- a/chunkserver/src/main/resources/application.properties
+++ b/chunkserver/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=8081
+chunkmaster.url=http://localhost:8080/chunkMaster


### PR DESCRIPTION
- chunkserver maintains hashmap with filename as key, and list of chunks as values. 

- On Store request, add chunk to the map, as well as add a chunk file to the system, stored as directory structure -{user.dir}/files/filename/chunkId.txt

- On retrieve request, chunkserver just responds with chunk by looking into the hashmap.

- On chunkserver restart, initiates the hashmap with the chunks saved before, by looking in the {user.dir}/files/ directory

- If chunk storage request comes, for same filename and chunkId as earlier, old one is replaced by new one.

- on chunkserver startup, send request to chunkmaster to add chunkserver